### PR TITLE
Fixes #21 liquidateStakeAccount: referral program deposit operation fee calculated to available mSOL for unstake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,9 @@
 v4.0.0
 
 Uses Referral-Program V2
+
+v4.0.1
+
+Fix incorrect mSOL amount calculation in function liquidateStakeAccount, when using a referral code
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@marinade.finance/marinade-ts-sdk",
-  "version": "3.1.3",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@marinade.finance/marinade-ts-sdk",
-      "version": "3.1.3",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
         "@project-serum/anchor": "^0.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/marinade-ts-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Marinade SDK for Typescript",
   "main": "dist/src/index.js",
   "repository": {


### PR DESCRIPTION
The composite operation `liquidateStakeAccount` needs to consider the deposit fee that's paid to partner in mSOL. After the deposit the available mSOL for unstake is reduced for the fee.