### PR TITLE
Txn simulation of liquidateStake operations in integration tests

### DIFF
--- a/test/marinade-finance-instructions.spec.ts
+++ b/test/marinade-finance-instructions.spec.ts
@@ -78,10 +78,8 @@ describe('Marinade Finance', () => {
     })
   })
 
-  describe.skip('depositStakeAccount', () => {
-    it('deposits stake account', async() => {
-      console.log('ReferralCode:', TestWorld.REFERRAL_CODE.toBase58())
-
+  describe('depositStakeAccount', () => {
+    it('deposits stake account (simulate)', async() => {
       const config = new MarinadeConfig({
         connection: TestWorld.CONNECTION,
         publicKey: TestWorld.SDK_USER.publicKey,
@@ -89,14 +87,21 @@ describe('Marinade Finance', () => {
       const marinade = new Marinade(config)
 
       // Make sure stake account still exist, if this test is included
-      const { transaction } = await marinade.depositStakeAccount(new web3.PublicKey('AtL1WfGDuyB2NvnqvuMuwJu4QwtiLyAhoczH5ESy7kNZ'))
-      const transactionSignature = await TestWorld.PROVIDER.send(transaction)
-      console.log('Deposit stake account tx:', transactionSignature)
+      const { transaction }
+        = await marinade.depositStakeAccount(new web3.PublicKey('AtL1WfGDuyB2NvnqvuMuwJu4QwtiLyAhoczH5ESy7kNZ'))
+
+      const {executedSlot, simulatedSlot, err, logs, unitsConsumed }
+        = await TestWorld.simulateTransaction(transaction)
+
+      expect(err).toBeNull()  // no error at simulation
+      expect(simulatedSlot).toBeGreaterThanOrEqual(executedSlot)
+      expect(unitsConsumed).toBeGreaterThan(0)  // something has been processed
+      console.debug('Deposit stake account tx logs:', logs)
     })
   })
 
-  describe.skip('liquidateStakeAccount', () => {
-    it('liquidates stake account', async() => {
+  describe('liquidateStakeAccount', () => {
+    it('liquidates stake account (simulate)', async() => {
       const config = new MarinadeConfig({
         connection: TestWorld.CONNECTION,
         publicKey: TestWorld.SDK_USER.publicKey,
@@ -104,9 +109,15 @@ describe('Marinade Finance', () => {
       const marinade = new Marinade(config)
 
       // Make sure stake account still exist, if this test is included
-      const { transaction } = await marinade.liquidateStakeAccount(new web3.PublicKey('7Pi7ye5SaKMFp1J6W4kygmAYYhotwoRLTk67Z1kcCcv4'))
-      const transactionSignature = await TestWorld.PROVIDER.send(transaction)
-      console.log('Liquidate stake account tx:', transactionSignature)
+      const { transaction }
+        = await marinade.liquidateStakeAccount(new web3.PublicKey('7Pi7ye5SaKMFp1J6W4kygmAYYhotwoRLTk67Z1kcCcv4'))
+      const {executedSlot, simulatedSlot, err, logs, unitsConsumed }
+        = await TestWorld.simulateTransaction(transaction)
+
+      expect(err).toBeNull()  // no error at simulation
+      expect(simulatedSlot).toBeGreaterThanOrEqual(executedSlot)
+      expect(unitsConsumed).toBeGreaterThan(0)  // something has been processed
+      console.log('Liquidate stake account tx logs:', logs)
     })
   })
 })

--- a/test/marinade-referral-instructions.spec.ts
+++ b/test/marinade-referral-instructions.spec.ts
@@ -40,18 +40,26 @@ describe('Marinade Referral', () => {
     })
   })
 
-  describe.skip('liquidateStakeAccount', () => {
-    it('liquidates stake account to SOL', async() => {
+  describe("liquidateStakeAccount", () => {
+    it("liquidates stake account (simulation)", async() => {
       const config = new MarinadeConfig({
         connection: TestWorld.CONNECTION,
         publicKey: TestWorld.SDK_USER.publicKey,
-        referralCode: TestWorld.REFERRAL_CODE,
       })
       const marinade = new Marinade(config)
 
-      const { transaction } = await marinade.liquidateStakeAccount(new web3.PublicKey("Cp4JSgUrPVaqMkr6m4KEu5yyu1khPTHQHrMNn5wfQabp"))
-      const transactionSignature = await TestWorld.PROVIDER.send(transaction)
-      console.log('Liquididate stake account tx:', transactionSignature)
+      // Make sure stake account still exist, if this test is included
+      const { transaction } = await marinade.liquidateStakeAccount(
+        new web3.PublicKey("FPFQJ7SNx2ZgpJ4nSuqzAhpofDdKMxN9sT8FDXpxGxng")
+      )
+
+      const { executedSlot, simulatedSlot, err, logs, unitsConsumed }
+        = await TestWorld.simulateTransaction(transaction)
+
+      expect(err).toBeNull()  // no error at simulation
+      expect(simulatedSlot).toBeGreaterThanOrEqual(executedSlot)
+      expect(unitsConsumed).toBeGreaterThan(0)  // some actions were processed
+      console.debug("Liquidate stake account tx log:", logs)
     })
   })
 })

--- a/test/test-world.ts
+++ b/test/test-world.ts
@@ -48,3 +48,18 @@ export const provideMinimumLamportsBalance = async(account: web3.PublicKey, mini
     remainingLamportsToAirdrop = remainingLamportsToAirdrop.sub(airdropLamports)
   }
 }
+
+export const simulateTransaction = async(transaction: web3.Transaction) => {
+  const {
+    context: { slot: executedSlot },
+    value: { blockhash },
+  } = await PROVIDER.connection.getLatestBlockhashAndContext()
+  transaction.recentBlockhash = blockhash
+  transaction.feePayer = SDK_USER.publicKey
+
+  const {
+    context: { slot: simulatedSlot },
+    value: { err, logs, unitsConsumed, accounts, returnData },
+  } = await PROVIDER.connection.simulateTransaction(transaction)
+  return {executedSlot, simulatedSlot, err, logs, unitsConsumed, accounts, returnData}
+}


### PR DESCRIPTION
Enabling tests for `liquidStake` operation that would normally remove the stake account and thus it cannot be directly executed as the test would not be replayable (creating new staking account takes time plus it needs to wait 2 epochs before unstaking).
For that the tests uses the simulation of the transaction.

@MjCage
* As the simulation works for referral program I think it's worthy to enable it for finance program tests as well.
* The call `TestWorld.PROVIDER.simulate` fails with `TypeError: connection._recentBlockhash is not a function` which I assume is reasoned by fact of SDK deprecating call on recent blockhash for slot. I created a method at `TestWorld` for reuse.
* Comments warn at code that the accounts used for tests should be checked if exist. Do you think there should be some pre-check in the code (like `TestWorld.PROVIDER.connection.getAccountInfo...`) to verify if account exists and if not then fails the test with some informative message, or is it ok with the comment in the code as it's now.