### PR TITLE
[fix] stake account isLockedUp check to apply current epoch and timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## v5.0.4
 
-### Feat:
+### Fix:
 
-    - Add beta support to (partially) deposit activating stake accounts via `depositActivatingStakeAccount`
-    - Make `createDirectedStakeVoteIx` public so it can be used in various transactions (like when swapping LSTs via Jup)
+    - Make it possible to stake locked stake accounts that have the lock period in the past
 
 ## v5.0.3
 
 ### Feat:
 
+    - Add beta support to (partially) deposit activating stake accounts via `depositActivatingStakeAccount`
+    - Make `createDirectedStakeVoteIx` public so it can be used in various transactions (like when swapping LSTs via Jup)
     - Add setup to run integration tests on local validator within the pipeline
     - Add beta support to partially deposit stake accounts via `partiallyDepositStakeAccount`
     - Add beta support to partially liquidate stake accounts via `partiallyLiquidateStakeAccount`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marinade.finance/marinade-ts-sdk",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Marinade SDK for Typescript",
   "main": "dist/src/index.js",
   "repository": {

--- a/src/util/anchor.ts
+++ b/src/util/anchor.ts
@@ -117,6 +117,8 @@ export async function getParsedStakeAccountInfo(
   const stakedLamports = BNOrNull(
     parsedData?.info?.stake?.delegation.stake ?? null
   )
+  const { epoch: currentEpoch } = await connection.getEpochInfo()
+  const currentUnixTimestamp = Date.now() / 1000
 
   return {
     address: stakeAccountAddress,
@@ -134,7 +136,10 @@ export async function getParsedStakeAccountInfo(
     deactivationEpoch,
     isCoolingDown: deactivationEpoch ? !deactivationEpoch.eq(U64_MAX) : false,
     isLockedUp:
-      lockup?.custodian && lockup?.custodian !== '' && lockup?.epoch > 0,
+      lockup?.custodian &&
+      lockup?.custodian !== '' &&
+      (lockup?.epoch > currentEpoch ||
+        lockup?.unixTimestamp > currentUnixTimestamp),
     balanceLamports,
     stakedLamports,
   }


### PR DESCRIPTION
Fixing a way how the stake account is evaluated to be locked-up. The prior version has not considered time or epoch could elapse.

See `Lockup.is_in_force` https://github.com/solana-labs/solana/blob/v1.14.24/sdk/program/src/stake/state.rs#L149

TS client parsed account: `stakeAccountInfo.data?.parsed.info` format

```
{
  meta: {
    authorized: {
      staker: 'CUuLjSEx7q3AB3sRGn3sMJBsSNTmULwowMGUh6NdsxQD',
      withdrawer: 'CUuLjSEx7q3AB3sRGn3sMJBsSNTmULwowMGUh6NdsxQD'
    },
    lockup: {
      custodian: '4Cp948vFSft1QRN2cAeVgdQvvn6fkAgSrRc9QHJFsL1Y',
      epoch: 4,
      unixTimestamp: 0
    },
    rentExemptReserve: '2282880'
  },
  stake: ...
}
```