### PR TITLE
[github workflow] update pnpm version to 8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,13 +12,13 @@ jobs:
         node-version: [16]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 7
       - name: Install, build and test

--- a/src/util/anchor.ts
+++ b/src/util/anchor.ts
@@ -100,7 +100,11 @@ export async function getParsedStakeAccountInfo(
     )
   }
 
-  if (!stakeAccountInfo.data || stakeAccountInfo.data instanceof Buffer) {
+  if (
+    !stakeAccountInfo.data ||
+    stakeAccountInfo.data instanceof Buffer ||
+    !('parsed' in stakeAccountInfo.data)
+  ) {
     throw new Error('Failed to parse the stake account data')
   }
 


### PR DESCRIPTION
Fix for github workflow error 

```
ERROR in /__w/marinade-ts-sdk/marinade-ts-sdk/src/util/anchor.ts
./src/util/anchor.ts 107:10-16
[tsl] ERROR in /__w/marinade-ts-sdk/marinade-ts-sdk/src/util/anchor.ts(107,11)
      TS2339: Property 'parsed' does not exist on type 'Buffer<ArrayBufferLike> | ParsedAccountData'.
ts-loader-default_e3b0c44298fc1c14
 @ ./src/marinade.ts 20:17-41
 @ ./src/index.ts 40:17-38
```

The error is not shown by combining newer `tsc` and `pnpm`. As the build is currently running on nodejs16 and the new pnpm (v 9) is compatible only with nodejs18+ thus I changed the code to verify the existence of the property for the `tsc` would not blame us.

note: changes in `build-test.yml` are only cosmetic and have no impact on fixing of the failure